### PR TITLE
Fix : checkChainData() being called every transaction

### DIFF
--- a/main.go
+++ b/main.go
@@ -431,7 +431,7 @@ func runBotTransaction(ctx context.Context, Clients *ethclient.Client, recipient
 
 	err = Clients.SendTransaction(ctx, signedTx)
 	if err != nil {
-		fmt.Printf("Error in sending tx: %s, From : %s, To : %s", err, sender.addr, recipient.Hash())
+		fmt.Printf("Error in sending tx: %s, From : %s, To : %s\n", err, sender.addr, recipient.Hash())
 	}
 	// Nonce++
 	CURRENT_ITERATIONS++

--- a/main.go
+++ b/main.go
@@ -262,6 +262,22 @@ type Nonces struct {
 func startLoadbot(ctx context.Context, client *ethclient.Client, chainID *big.Int,
 	genAccounts Accounts) {
 
+	if MAX_SIZE > 0 {
+		go func() {
+			for {
+
+				currentSize := checkChainData()
+				if (currentSize - INITIAL_SIZE) > int64(MAX_SIZE) {
+					fmt.Println("Size limit reached!!!")
+					os.Exit(0)
+				}
+
+				time.Sleep(5 * time.Second)
+			}
+
+		}()
+	}
+
 	fmt.Printf("Loadbot started \n")
 	noncesStruct := &Nonces{
 		nonces: make([]uint64, N),
@@ -300,15 +316,6 @@ func startLoadbot(ctx context.Context, client *ethclient.Client, chainID *big.In
 			fmt.Println("CURRENT_ACCOUNTS: ", CURRENT_ITERATIONS)
 			if MAX_ACCOUNTS > 0 && CURRENT_ITERATIONS >= MAX_ACCOUNTS {
 				os.Exit(0)
-			}
-
-			// checkChainDataByScript()
-			if MAX_SIZE > 0 {
-				currentSize := checkChainData()
-				if (currentSize - INITIAL_SIZE) > int64(MAX_SIZE) {
-					fmt.Println("Size limit reached!!!")
-					os.Exit(0)
-				}
 			}
 
 			recpIdx++

--- a/main.go
+++ b/main.go
@@ -272,7 +272,7 @@ func startLoadbot(ctx context.Context, client *ethclient.Client, chainID *big.In
 					os.Exit(0)
 				}
 
-				time.Sleep(5 * time.Second)
+				time.Sleep(10 * time.Second)
 			}
 
 		}()

--- a/main.go
+++ b/main.go
@@ -313,7 +313,7 @@ func startLoadbot(ctx context.Context, client *ethclient.Client, chainID *big.In
 		select {
 		case <-ticker.C:
 
-			if CURRENT_ITERATIONS%100 == 0 {
+			if CURRENT_ITERATIONS%100 == 0 && CURRENT_ITERATIONS > 0 {
 				fmt.Println("CURRENT_ACCOUNTS: ", CURRENT_ITERATIONS)
 			}
 			if MAX_ACCOUNTS > 0 && CURRENT_ITERATIONS >= MAX_ACCOUNTS {

--- a/main.go
+++ b/main.go
@@ -429,7 +429,7 @@ func runBotTransaction(ctx context.Context, Clients *ethclient.Client, recipient
 
 	err = Clients.SendTransaction(ctx, signedTx)
 	if err != nil {
-		log.Fatalf("Error in sending tx: %s, From : %s, To : %s", err, sender.addr, recipient.Hash())
+		fmt.Printf("Error in sending tx: %s, From : %s, To : %s", err, sender.addr, recipient.Hash())
 	}
 	// Nonce++
 	CURRENT_ITERATIONS++

--- a/main.go
+++ b/main.go
@@ -313,7 +313,9 @@ func startLoadbot(ctx context.Context, client *ethclient.Client, chainID *big.In
 		select {
 		case <-ticker.C:
 
-			fmt.Println("CURRENT_ACCOUNTS: ", CURRENT_ITERATIONS)
+			if CURRENT_ITERATIONS%100 == 0 {
+				fmt.Println("CURRENT_ACCOUNTS: ", CURRENT_ITERATIONS)
+			}
 			if MAX_ACCOUNTS > 0 && CURRENT_ITERATIONS >= MAX_ACCOUNTS {
 				os.Exit(0)
 			}


### PR DESCRIPTION
Earlier, checkChainData was being called after every transaction is fired. This could potentially slow down the tx sending process specially when the `chainData is huge` and takes to time to get calculated. 

In this PR, we fix this by calculating chainData every 10 seconds in a separate go-routine. 

